### PR TITLE
Fix `See also` Sphinx headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+9.1.4
+-----
+
+* use fork friendly random robust queue generation way #560
+
 9.1.3
 -----
 

--- a/aio_pika/robust_queue.py
+++ b/aio_pika/robust_queue.py
@@ -1,3 +1,4 @@
+import uuid
 import warnings
 from random import Random
 from typing import Any, Awaitable, Callable, Dict, Optional, Tuple, Union
@@ -28,8 +29,7 @@ class RobustQueue(Queue, AbstractRobustQueue):
 
     @classmethod
     def _get_random_queue_name(cls) -> str:
-        rnd = cls._rnd_gen.getrandbits(128)
-        return "amq_%s" % hex(rnd).lower()
+        return f"amq_{uuid.uuid4().hex}"
 
     def __init__(
         self,

--- a/aio_pika/robust_queue.py
+++ b/aio_pika/robust_queue.py
@@ -1,6 +1,5 @@
 import uuid
 import warnings
-from random import Random
 from typing import Any, Awaitable, Callable, Dict, Optional, Tuple, Union
 
 import aiormq
@@ -25,12 +24,6 @@ class RobustQueue(Queue, AbstractRobustQueue):
     _consumers: Dict[ConsumerTag, Dict[str, Any]]
     _bindings: Dict[Tuple[Union[AbstractExchange, str], str], Dict[str, Any]]
 
-    _rnd_gen: Random = Random()
-
-    @classmethod
-    def _get_random_queue_name(cls) -> str:
-        return f"amq_{uuid.uuid4().hex}"
-
     def __init__(
         self,
         channel: AbstractChannel,
@@ -44,7 +37,7 @@ class RobustQueue(Queue, AbstractRobustQueue):
 
         super().__init__(
             channel=channel,
-            name=name or self._get_random_queue_name(),
+            name=name or f"amq_{uuid.uuid4().hex}",
             durable=durable,
             exclusive=exclusive,
             auto_delete=auto_delete,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aio-pika"
-version = "9.1.3"
+version = "9.1.4"
 description = "Wrapper around the aiormq for asyncio and humans"
 authors = ["Dmitry Orlov <me@mosquito.su>"]
 readme = "README.rst"


### PR DESCRIPTION
My bad, I am not a .rst user, thus made a mistake

For some reason, github and sphinx are using the different .rst parsers (or differ from [this guide](https://thomas-cokelaer.info/tutorials/sphinx/rest_syntax.html#headings)) and the same README markup represents wrong in `aio-pika` sphinx doc: there no any `See also` sections subtitles.

So I fix It and now we have the following view:
![image](https://github.com/Lancetnik/aio-pika/assets/44573917/24cbf812-e970-440f-b454-98855e9afaa2)

Instead the current:
![image](https://github.com/Lancetnik/aio-pika/assets/44573917/e993112d-8028-4ff6-9f0d-5d533765f70f)

